### PR TITLE
Github アカウントでログインできるようにした

### DIFF
--- a/kpt/app/Http/Controllers/HomeController.php
+++ b/kpt/app/Http/Controllers/HomeController.php
@@ -7,15 +7,15 @@ use Laravel\Socialite\Facades\Socialite;
 
 class HomeController extends Controller
 {
-  public function index()
-  {
-      return view('home.index');
-  }
+    public function index()
+    {
+        return view('home.index');
+    }
 
-  public function callback()
-  {
-      $user = Socialite::driver('github')->user();
-      return view('home.callback', ['user' => $user]);
-      # return redirect()->route('kpt');
-  }
+    public function callback()
+    {
+        $user = Socialite::driver('github')->user();
+        return view('home.callback', ['user' => $user]);
+        # return redirect()->route('kpt');
+    }
 }

--- a/kpt/app/Http/Controllers/HomeController.php
+++ b/kpt/app/Http/Controllers/HomeController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Laravel\Socialite\Facades\Socialite;
+
+class HomeController extends Controller
+{
+  public function index()
+  {
+      return view('home.index');
+  }
+
+  public function callback()
+  {
+      $user = Socialite::driver('github')->user();
+      return view('home.callback', ['user' => $user]);
+      # return redirect()->route('kpt');
+  }
+}

--- a/kpt/composer.json
+++ b/kpt/composer.json
@@ -13,6 +13,7 @@
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
+        "laravel/socialite": "^5.1",
         "laravel/tinker": "^2.5"
     },
     "require-dev": {

--- a/kpt/composer.lock
+++ b/kpt/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "135c9d9a76217bddbd7f4465f9bfef3d",
+    "content-hash": "ebcb5b0435df5c41a08cce2a1866e2c0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1060,6 +1060,75 @@
             "time": "2020-12-22T21:21:19+00:00"
         },
         {
+            "name": "laravel/socialite",
+            "version": "v5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/socialite.git",
+                "reference": "2e6beafe911a09f2300353c102d882e9d63f1f72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/2e6beafe911a09f2300353c102d882e9d63f1f72",
+                "reference": "2e6beafe911a09f2300353c102d882e9d63f1f72",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "illuminate/http": "^6.0|^7.0|^8.0",
+                "illuminate/support": "^6.0|^7.0|^8.0",
+                "league/oauth1-client": "^1.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "illuminate/contracts": "^6.0|^7.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^4.0|^5.0|^6.0",
+                "phpunit/phpunit": "^8.0|^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Socialite\\SocialiteServiceProvider"
+                    ],
+                    "aliases": {
+                        "Socialite": "Laravel\\Socialite\\Facades\\Socialite"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Socialite\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel wrapper around OAuth 1 & OAuth 2 libraries.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "laravel",
+                "oauth"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/socialite/issues",
+                "source": "https://github.com/laravel/socialite"
+            },
+            "time": "2021-01-05T17:02:09+00:00"
+        },
+        {
             "name": "laravel/tinker",
             "version": "v2.5.0",
             "source": {
@@ -1377,6 +1446,81 @@
                 }
             ],
             "time": "2020-10-18T11:50:25+00:00"
+        },
+        {
+            "name": "league/oauth1-client",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth1-client.git",
+                "reference": "1e7e6be2dc543bf466236fb171e5b20e1b06aee6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth1-client/zipball/1e7e6be2dc543bf466236fb171e5b20e1b06aee6",
+                "reference": "1e7e6be2dc543bf466236fb171e5b20e1b06aee6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "php": ">=7.1||>=8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "mockery/mockery": "^1.3.3",
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5||9.5"
+            },
+            "suggest": {
+                "ext-simplexml": "For decoding XML-based responses."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth1\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Corlett",
+                    "email": "bencorlett@me.com",
+                    "homepage": "http://www.webcomm.com.au",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OAuth 1.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "bitbucket",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth1",
+                "single sign on",
+                "trello",
+                "tumblr",
+                "twitter"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth1-client/issues",
+                "source": "https://github.com/thephpleague/oauth1-client/tree/v1.9.0"
+            },
+            "time": "2021-01-20T01:40:53+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/kpt/config/services.php
+++ b/kpt/config/services.php
@@ -30,4 +30,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'github' => [
+      'client_id' => env('GITHUB_CLIENT_ID'),
+      'client_secret' => env('GITHUB_CLIENT_SECRET'),
+      'redirect' => 'http://localhost/callback'
+    ]
 ];

--- a/kpt/resources/views/home/callback.blade.php
+++ b/kpt/resources/views/home/callback.blade.php
@@ -1,0 +1,16 @@
+<html>
+  <head></head>
+  <body>
+    <div>
+      ログイン済み
+      <ul>
+        <li>{{ $user->token }}</li>
+        <li>{{ $user->getId() }}</li>
+        <li>{{ $user->getNickname() }}</li>
+        <li>{{ $user->getName() }}</li>
+        <li>{{ $user->getEmail() }}</li>
+        <li>{{ $user->getAvatar() }}</li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/kpt/resources/views/home/index.blade.php
+++ b/kpt/resources/views/home/index.blade.php
@@ -1,0 +1,8 @@
+<html>
+  <head></head>
+  <body>
+    <div>
+      <a href="{{ route('login.github') }}">Github アカウントでログインする</a>
+    </div>
+  </body>
+</html>

--- a/kpt/routes/web.php
+++ b/kpt/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Laravel\Socialite\Facades\Socialite;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,14 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/auth/redirect', function() {
+    return Socialite::driver('github')->redirect();
+});
+
+Route::get('/auth/callback', function() {
+    $user = Socialite::driver('github')->user();
+    $token = $user->token;
+    Log::debug($token);
+});
+

--- a/kpt/routes/web.php
+++ b/kpt/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Socialite\Facades\Socialite;
 use App\Http\Controllers\HomeController;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -16,9 +17,8 @@ use App\Http\Controllers\HomeController;
 
 Route::get('/', [HomeController::class, 'index']);
 
-Route::get('/auth/redirect', function() {
+Route::get('/auth/redirect', function () {
     return Socialite::driver('github')->redirect();
 })->name('login.github');
 
 Route::get('/callback', [HomeController::class, 'callback']);
-

--- a/kpt/routes/web.php
+++ b/kpt/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Laravel\Socialite\Facades\Socialite;
-
+use App\Http\Controllers\HomeController;
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -14,17 +14,11 @@ use Laravel\Socialite\Facades\Socialite;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [HomeController::class, 'index']);
 
 Route::get('/auth/redirect', function() {
     return Socialite::driver('github')->redirect();
-});
+})->name('login.github');
 
-Route::get('/auth/callback', function() {
-    $user = Socialite::driver('github')->user();
-    $token = $user->token;
-    Log::debug($token);
-});
+Route::get('/callback', [HomeController::class, 'callback']);
 


### PR DESCRIPTION
## やったこと

Github の認証をして、Github アカウントの情報が取得できるようにしました。

動かすには .env ファイルに
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET
を入れておく必要があります。

Organization としてアプリを作ると良さそうなのですが、なんかよくわからなかったので、個人アカウントに紐づける形で認証用のアプリを作って動作確認しました。

ここから作れます。
https://github.com/settings/developers

## やらなかったこと
取得した情報をデータベースに保存する処理は入れてません。
実際には Github から取得した ID とメールアドレスをDBに保存をして、次回ログイン時に会員情報と紐付けができるようにします。

## 参考
Laraval で Github ログインをする方法
https://laravel.com/docs/8.x/socialite