### PR TITLE
app コンテナで npm install コマンドを使いたかったので node を追加

### DIFF
--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -24,6 +24,10 @@ RUN apt-get update && \
   composer config -g process-timeout 3600 && \
   composer config -g repos.packagist composer https://packagist.org
 
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install npm@latest -g
+
 COPY ./infra/docker/php/php-fpm.d/zzz-www.conf /usr/local/etc/php-fpm.d/zzz-www.conf
 COPY ./infra/docker/php/php.ini /usr/local/etc/php/php.ini
 


### PR DESCRIPTION
app コンテナ内で npm install がしたかったので、
node.js を追加しました

npm install を使えるようにするには、一度コンテナを作り直す必要があります。

```
docker-compose build app
docker-compose up
```