### PR TITLE
Web containerのwork directoryを修正

### DIFF
--- a/infra/docker/nginx/Dockerfile
+++ b/infra/docker/nginx/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=node /opt /opt
 # nginx config file
 COPY ./infra/docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 
-WORKDIR /work/backend
+WORKDIR /kpt


### PR DESCRIPTION
## 概要

Web docker containerのwork directoryが正しくなかったため、`make yarn`系のコマンドが実行できなかった。