### PR TITLE
Teams-Usersテーブル間のDB構造の修正

### DIFF
--- a/database/migrations/2021_06_12_020527_delete_colum_from_teams.php
+++ b/database/migrations/2021_06_12_020527_delete_colum_from_teams.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DeleteColumFromTeams extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            //外部キー削除
+            $table->dropForeign(['user_id']);
+
+            //カラム自体の削除
+            $table->dropColumn('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+}


### PR DESCRIPTION
## 概要
resolve #44  

https://github.com/nanas773/kpt-design/blob/main/database_er_diagram.png
上記ER図に合わせてテーブルを修正

## やること
- [x] TeamsとUsersの中間テーブル`Team_users`の作成
- [x] TeamsとUsersのカラム修正

